### PR TITLE
Add Inter font and MUI theme; style AddDevs

### DIFF
--- a/MtdrSpring/backend/src/main/frontend/package-lock.json
+++ b/MtdrSpring/backend/src/main/frontend/package-lock.json
@@ -16576,6 +16576,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",

--- a/MtdrSpring/backend/src/main/frontend/src/App.js
+++ b/MtdrSpring/backend/src/main/frontend/src/App.js
@@ -1,13 +1,21 @@
 import './App.css';
 import { useState } from 'react'
 import AppRouter from './routes/AppRouter'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+const theme = createTheme({
+  typography: {
+    fontFamily: 'Inter, Roboto, sans-serif',
+  },
+})
 // import './Assets/styles.css'
 
 function App() {
 
   const [isAuth, setIsAuth] = useState(false)
   return (
+    <ThemeProvider theme={theme}>
     <AppRouter isAuth={isAuth} setIsAuth={setIsAuth} />
+    </ThemeProvider>
   )
 }
 

--- a/MtdrSpring/backend/src/main/frontend/src/index.css
+++ b/MtdrSpring/backend/src/main/frontend/src/index.css
@@ -1,9 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 body {
   margin: 0;
   background-color: #f1efed;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/MtdrSpring/backend/src/main/frontend/src/pages/AddDevs.js
+++ b/MtdrSpring/backend/src/main/frontend/src/pages/AddDevs.js
@@ -95,15 +95,30 @@ function AddDevs() {
             )}
 
             {members.map(member => (
+          
               <Box
-                key={member.id}
-                className="devs-task-card"
-                sx={{ mb: 1 }}
-              >
-                <Typography fontWeight="bold" fontSize="0.9rem">
-                  {member.name} {member.lastName}
-                </Typography>
-              </Box>
+              key={member.id}
+              className="devs-task-card"
+              sx={{
+                mb: 1,
+                p: 4,              // más espacio interno
+                minHeight: 60,     // altura mínima
+                display: 'flex',
+                alignItems: 'center'
+              }}
+            >
+              
+              <Typography variant="h6" fontWeight={600}>
+                {member.name} {member.lastName}
+              </Typography>
+
+
+
+              
+            </Box>
+
+              
+              
             ))}
           </Box>
         </Box>


### PR DESCRIPTION
Wrap AppRouter in a MUI ThemeProvider and define a theme that sets the typography fontFamily to Inter (with fallbacks). Import the Inter Google font in index.css and update the body font-family to use it. Improve AddDevs list item styling by increasing padding, setting a minimum height, centering content, and using a bolder Typography variant for names to improve visual hierarchy.