### PR TITLE
Persist auth & add role-based routing

### DIFF
--- a/MtdrSpring/backend/src/main/frontend/src/App.js
+++ b/MtdrSpring/backend/src/main/frontend/src/App.js
@@ -11,10 +11,21 @@ const theme = createTheme({
 
 function App() {
 
-  const [isAuth, setIsAuth] = useState(false)
+  const [isAuth, setIsAuth] = useState(
+    localStorage.getItem('isAuth') === 'true'
+  )
+  const [user, setUser] = useState(() => {
+    const savedUser = localStorage.getItem('user')
+    return savedUser ? JSON.parse(savedUser) : null
+  })
   return (
     <ThemeProvider theme={theme}>
-    <AppRouter isAuth={isAuth} setIsAuth={setIsAuth} />
+    <AppRouter
+      isAuth={isAuth}
+      setIsAuth={setIsAuth}
+      user={user}
+      setUser={setUser}
+    />
     </ThemeProvider>
   )
 }

--- a/MtdrSpring/backend/src/main/frontend/src/components/Navbar.js
+++ b/MtdrSpring/backend/src/main/frontend/src/components/Navbar.js
@@ -27,6 +27,9 @@ function Navbar(props) {
   }, []);
 
   const handleLogout = () => {
+    localStorage.removeItem('isAuth');
+    localStorage.removeItem('user');
+    props.setUser(null);
     props.setIsAuth(false);
     navigate('/');
   };
@@ -80,49 +83,57 @@ function Navbar(props) {
             </Button>
 
             {/* DASHBOARD */}
-            <Button
-              className={`nav-button icon-btn ${scrolled ? 'scrolled' : ''} ${isActive('/dashboard') ? 'active' : ''}`}
-              onClick={() => navigate('/dashboard')}
-            >
-              <span className="icon">
-                <DashboardIcon fontSize="small" />
-              </span>
-              <span className="label">Dashboard</span>
-            </Button>
+            {props.user?.roleName === 'Product Owner' && (
+              <Button
+                className={`nav-button icon-btn ${scrolled ? 'scrolled' : ''} ${isActive('/dashboard') ? 'active' : ''}`}
+                onClick={() => navigate('/dashboard')}
+              >
+                <span className="icon">
+                  <DashboardIcon fontSize="small" />
+                </span>
+                <span className="label">Dashboard</span>
+              </Button>
+            )}
 
             {/* GESTION DE TAREAS */}
-            <Button
-              className={`nav-button icon-btn ${scrolled ? 'scrolled' : ''} ${isActive('/gestion') ? 'active' : ''}`}
-              onClick={() => navigate('/gestion')}
-            >
-              <span className="icon">
-                <AppRegistrationIcon fontSize="small" />
-              </span>
-              <span className="label">Gestion</span>
-            </Button>
+            {props.user?.roleName === 'Product Owner' && (
+              <Button
+                className={`nav-button icon-btn ${scrolled ? 'scrolled' : ''} ${isActive('/gestion') ? 'active' : ''}`}
+                onClick={() => navigate('/gestion')}
+              >
+                <span className="icon">
+                  <AppRegistrationIcon fontSize="small" />
+                </span>
+                <span className="label">Gestion</span>
+              </Button>
+            )}
 
 
             {/* DEVELOPERS */}
-            <Button
-              className={`nav-button icon-btn ${scrolled ? 'scrolled' : ''} ${isActive('/DashDevs') ? 'active' : ''}`}
-              onClick={() => navigate('/DashDevs')}
-            >
-              <span className="icon">
-                <CodeIcon fontSize="small" />
-              </span>
-              <span className="label">Developers</span>
-            </Button>
+            {props.user?.roleName === 'Developer' && (
+              <Button
+                className={`nav-button icon-btn ${scrolled ? 'scrolled' : ''} ${isActive('/DashDevs') ? 'active' : ''}`}
+                onClick={() => navigate('/DashDevs')}
+              >
+                <span className="icon">
+                  <CodeIcon fontSize="small" />
+                </span>
+                <span className="label">Developers</span>
+              </Button>
+            )}
 
             {/* ADD DEVELOPERS */}
-            <Button
-              className={`nav-button icon-btn ${scrolled ? 'scrolled' : ''} ${isActive('/AddDevs') ? 'active' : ''}`}
-              onClick={() => navigate('/AddDevs')}
-            >
-              <span className="icon">
-                <AssignmentIndIcon fontSize="small" />
-              </span>
-              <span className="label">Registrar</span>
-            </Button>
+            {props.user?.roleName === 'Product Owner' && (
+              <Button
+                className={`nav-button icon-btn ${scrolled ? 'scrolled' : ''} ${isActive('/AddDevs') ? 'active' : ''}`}
+                onClick={() => navigate('/AddDevs')}
+              >
+                <span className="icon">
+                  <AssignmentIndIcon fontSize="small" />
+                </span>
+                <span className="label">Registrar</span>
+              </Button>
+            )}
 
 
             {/* LOGOUT */}

--- a/MtdrSpring/backend/src/main/frontend/src/pages/login.js
+++ b/MtdrSpring/backend/src/main/frontend/src/pages/login.js
@@ -8,7 +8,7 @@ import VisibilityOff from '@mui/icons-material/VisibilityOff'
 import Footer from '../components/Footer'
 import '../Assets/styles.css'
 
-function Login({ setIsAuth }) {
+function Login({ setIsAuth, setUser }) {
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -25,6 +25,10 @@ function Login({ setIsAuth }) {
           body: JSON.stringify({ email, password }),
         });
         if (response.ok) {
+          const data = await response.json();
+          localStorage.setItem('isAuth', 'true');
+          localStorage.setItem('user', JSON.stringify(data));
+          setUser(data);
           setIsAuth(true);
           navigate('/dashboard');
         } else if (response.status === 401) {

--- a/MtdrSpring/backend/src/main/frontend/src/routes/AppRouter.js
+++ b/MtdrSpring/backend/src/main/frontend/src/routes/AppRouter.js
@@ -7,37 +7,60 @@ import Navbar from '../components/Navbar'
 import Gestion from '../pages/gestion'
 import AddDevs from '../pages/AddDevs'
 
-function AppRouter({ isAuth, setIsAuth }) {
+function AppRouter({ isAuth, setIsAuth, user, setUser }) {
   return (
     <BrowserRouter>
 
-      {isAuth && <Navbar setIsAuth={setIsAuth} />}
+      {isAuth && <Navbar setIsAuth={setIsAuth} setUser={setUser} user={user} />}
 
       <Box>
         {/* Esto empuja TODO el contenido debajo del navbar */}
         {isAuth && <Toolbar />}
 
         <Routes>
-          <Route path="/" element={<Login setIsAuth={setIsAuth} />} />
+          <Route
+            path="/"
+            element={
+              isAuth
+                ? <Navigate to="/dashboard" />
+                : <Login setIsAuth={setIsAuth} setUser={setUser} />
+            }
+          />
 
           <Route 
             path="/dashboard" 
-            element={isAuth ? <Dashboard /> : <Navigate to="/" />} 
+            element={
+              isAuth && user?.roleName === 'Product Owner'
+                ? <Dashboard />
+                : <Navigate to={isAuth ? "/DashDevs" : "/"} />
+            }
           />
 
           <Route
             path="/DashDevs"
-            element={isAuth ? <DashDevs /> : <Navigate to="/" />}
+            element={
+              isAuth && user?.roleName === 'Developer'
+                ? <DashDevs />
+                : <Navigate to="/dashboard" />
+            }
           />
 
           <Route
             path="/AddDevs"
-            element={isAuth ? <AddDevs /> : <Navigate to="/" />}
+            element={
+              isAuth && user?.roleName === 'Product Owner'
+                ? <AddDevs />
+                : <Navigate to={isAuth ? "/DashDevs" : "/"} />
+            }
           />
 
           <Route 
             path="/gestion" 
-            element={isAuth ? <Gestion /> : <Navigate to="/" />} 
+            element={
+              isAuth && user?.roleName === 'Product Owner'
+                ? <Gestion />
+                : <Navigate to={isAuth ? "/DashDevs" : "/"} />
+            }
           />
 
           <Route path="*" element={<Navigate to="/" />} />

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/UserController.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/UserController.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -24,9 +26,30 @@ public class UserController {
 
     @PostMapping(value = "/login")
     public ResponseEntity<?> login(@RequestBody Credential loginRequest) {
-        return credentialService.authenticate(loginRequest.getEmail(), loginRequest.getPassword())
-                .map(credential -> ResponseEntity.ok(credential))
-                .orElse(ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
+        Optional<Credential> credentialOpt =
+                credentialService.authenticate(loginRequest.getEmail(), loginRequest.getPassword());
+
+        if (credentialOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        Optional<User> userOpt = userService.getUserByEmail(loginRequest.getEmail());
+
+        if (userOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Usuario no encontrado");
+        }
+
+        User user = userOpt.get();
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("userId", user.getUserId());
+        response.put("email", user.getCredential().getEmail());
+        response.put("roleId", user.getRole().getRoleId());
+        response.put("roleName", user.getRole().getRoleName());
+        response.put("firstName", user.getFirtsName());
+        response.put("lastName", user.getLastName());
+
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping(value = "/users")

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/repository/UserRepository.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/repository/UserRepository.java
@@ -4,6 +4,9 @@ import com.springboot.MyTodoList.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByCredentialEmail(String email);
 }

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/UserService.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/UserService.java
@@ -26,6 +26,10 @@ public class UserService {
         return userRepository.findById(id);
     }
 
+    public Optional<User> getUserByEmail(String email) {
+        return userRepository.findByCredentialEmail(email);
+    }
+
     public void deleteUser(Long id) {
         userRepository.deleteById(id);
     }


### PR DESCRIPTION
Frontend: Persist authentication state and user info in localStorage (isAuth, user). App passes user and setUser through AppRouter and Navbar. Login stores user and isAuth on successful auth; Navbar logout clears them. Navbar now conditionally renders navigation buttons based on user.roleName (Product Owner vs Developer). AppRouter enforces role-based route access and redirects (root redirects to dashboard when authenticated, routes redirect according to role).

Backend: UserController.login now verifies credentials, loads the corresponding User, and returns a JSON payload with userId, email, roleId, roleName, firstName and lastName (returns 401 or 404 as appropriate). Added UserRepository.findByCredentialEmail and UserService.getUserByEmail to support user lookup by email.